### PR TITLE
Introduce `config.gem_mode`

### DIFF
--- a/lib/type_fusion/config.rb
+++ b/lib/type_fusion/config.rb
@@ -17,7 +17,7 @@ module TypeFusion
   class Config
     include Singleton
 
-    attr_accessor :type_sample_call_rate, :type_sample_request, :type_sample_tracepoint_path, :endpoint, :application_name
+    attr_accessor :type_sample_call_rate, :type_sample_request, :type_sample_tracepoint_path, :endpoint, :application_name, :gem_mode
 
     def initialize
       @type_sample_call_rate = 0.001
@@ -25,6 +25,7 @@ module TypeFusion
       @type_sample_tracepoint_path = ->(_tracepoint_path) { true }
       @endpoint = "https://gem.sh/api/v1/types/samples"
       @application_name = "TypeFusion"
+      @gem_mode = false
     end
 
     def type_sample_request?(env)

--- a/lib/type_fusion/sampler.rb
+++ b/lib/type_fusion/sampler.rb
@@ -31,11 +31,17 @@ module TypeFusion
 
           method_name = tracepoint.method_id
           location = tracepoint.binding.source_location.join(":")
-          gem_and_version = location.gsub(gem_path, "").split("/").first
-          gem, version = gem_and_version_from(gem_and_version)
           args = tracepoint.parameters.to_h(&:reverse)
           parameters = extract_parameters(args, tracepoint.binding)
           return_value = type_for_object(tracepoint.return_value)
+
+          if TypeFusion.config.gem_mode
+            # TODO: make this dynamic
+            gem, version = "countries", "5.6.0"
+          else
+            gem_and_version = location.gsub(gem_path, "").split("/").first
+            gem, version = gem_and_version_from(gem_and_version)
+          end
 
           sample_values = {
             gem_name: gem,
@@ -80,7 +86,7 @@ module TypeFusion
     def sample?(tracepoint_path)
       TypeFusion.config.type_sample_call? &&
         TypeFusion.config.type_sample_tracepoint_path?(tracepoint_path) &&
-        tracepoint_path.start_with?(gem_path)
+        (tracepoint_path.start_with?(gem_path) || TypeFusion.config.gem_mode)
     end
 
     def type_for_object(object)


### PR DESCRIPTION
This pull request introduces the `config.gem_mode` configuration. 

Previously we only sampled calls from gems within the `Gem.default_path` directory. The gem mode is meant to allow TypeFusion to be run as part of a test suite of a gem, so TypeFusion is able to sample the gem itself opposed to running it in an application where you only want to sample the gems of your application.

Resolves #4 

